### PR TITLE
Remove comma between number of minutes and 'minutes'-text.

### DIFF
--- a/client/views/problems/problem.js
+++ b/client/views/problems/problem.js
@@ -61,6 +61,6 @@ Template.showProblem.helpers({
     problemEnds: function() {
         var diff = this.activeTo - getTickingSecond();
         var duration = moment.duration(diff, 'milliseconds');
-        return duration.hours() + ' timer, ' + duration.minutes() + ', minutter og ' + duration.seconds() + ' sekunder';
+        return duration.hours() + ' timer, ' + duration.minutes() + ' minutter og ' + duration.seconds() + ' sekunder';
     }
 });


### PR DESCRIPTION
Removes the comma as highlighted in this picture.

![pasted image at 2016_12_01 18_49](https://cloud.githubusercontent.com/assets/5422571/20835268/e44bfe28-b899-11e6-81fb-684966a9bf4a.png)
